### PR TITLE
Update Dockerfile to use fluentd onbuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,13 @@
-FROM fluent/fluentd:latest
+FROM fluent/fluentd:v0.14-onbuild
 MAINTAINER Eljas Alakulppi <eljas@callstats.io>
-WORKDIR /home/fluent
-ENV PATH /home/fluent/.gem/ruby/2.3.0/bin:$PATH
 
-USER root
-RUN apk --no-cache --update add sudo build-base ruby-dev && \
-    sudo -u fluent gem install fluent-plugin-cloudwatch-logs && \
-    sudo -u fluent gem install fluent-plugin-kubernetes_metadata_filter && \
-    rm -rf /home/fluent/.gem/ruby/2.3.0/cache/*.gem && sudo -u fluent gem sources -c && \
-    apk del sudo build-base ruby-dev && rm -rf /var/cache/apk/*
+RUN apk add --update --virtual .build-deps \
+        sudo build-base ruby-dev \
+        && sudo gem install fluent-plugin-cloudwatch-logs \
+        && sudo gem install fluent-plugin-kubernetes_metadata_filter \
+        && sudo gem sources --clear-all \
+        && apk del .build-deps \
+        && rm -rf /var/cache/apk/* \
+                  /home/fluent/.gem/ruby/2.3.0/cache/*.gem
 
 EXPOSE 24284
-
-ADD fluent.conf /fluentd/etc/
-CMD exec fluentd -c /fluentd/etc/$FLUENTD_CONF -p /fluentd/plugins $FLUENTD_OPT


### PR DESCRIPTION
Fix the Dockerfile to use `:onbuild` instead of `:latest`.

Note that a plugins directory is necessary for the build.